### PR TITLE
Fix: Detect 3x-ui panel port from binary instead of hardcoded list

### DIFF
--- a/dnstm-setup.sh
+++ b/dnstm-setup.sh
@@ -2935,19 +2935,15 @@ detect_xray_panel() {
                 XRAY_PANEL_PORT=$(sqlite3 /etc/x-ui/x-ui.db "SELECT value FROM settings WHERE key='webPort'" 2>/dev/null || true)
             fi
         fi
+
+        # Method 3: Query x-ui binary directly to find the port
+        if [[ -z "$XRAY_PANEL_PORT" ]]; then
+            XRAY_PANEL_PORT=$(x-ui settings 2>&1 | grep -E '^[[:space:]]*port:' | awk -F': ' '{print $2}' | tr -d '[:space:]' || true)
+        fi
+
         # Validate port is numeric
         if [[ -n "$XRAY_PANEL_PORT" && ! "$XRAY_PANEL_PORT" =~ ^[0-9]+$ ]]; then
             XRAY_PANEL_PORT=""
-        fi
-
-        # Method 3: Try common 3x-ui ports (skip 443 — too likely to be nginx)
-        if [[ -z "$XRAY_PANEL_PORT" ]]; then
-            for port in 2053 54321 2087 2083; do
-                if ss -tlnp 2>/dev/null | grep -q ":${port} "; then
-                    XRAY_PANEL_PORT="$port"
-                    break
-                fi
-            done
         fi
 
         # Method 4: Fall back to default


### PR DESCRIPTION
Problem:
The script detected 3x-ui panels by scanning only hardcoded ports (2053, 54321, 2087, 2083). Users with custom panel ports experienced detection failures, causing the script to default to port 2053 or fail to connect entirely.

Solution:
Add Method 3 that queries  command to get the actual panel port directly from the binary. This works for any port configuration since the x-ui binary knows the difference between panel port and Xray inbound ports.

Changes:
- Replace hardcoded port scanning loop with  query

Testing:
- Tested on personal server with panel on non-default port
- Correctly detected panel port, not inbound ports
- Verified script behavior when x-ui is not installed